### PR TITLE
Fix docker-compose for linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 services:
   db:
     build: development/db


### PR DESCRIPTION
```
$ docker-compose up --build -V
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```

Add a fix for the above error that occurs in Linux by downgrading the docker-compose version to `3.7`.

Don't forget to use `sudo docker-compose up` instead of `docker-compose up` for it to work.