### PR TITLE
test: Clear word repository before running each test.

### DIFF
--- a/src/test/java/nl/hu/cisq1/lingo/words/application/WordServiceIntegrationTest.java
+++ b/src/test/java/nl/hu/cisq1/lingo/words/application/WordServiceIntegrationTest.java
@@ -73,6 +73,7 @@ class WordServiceIntegrationTest {
     @BeforeEach
     void loadTestData() {
         // Load test fixtures into test database before each test case
+        repository.deleteAll();
         repository.save(new Word(RANDOM_WORD_5));
         repository.save(new Word(RANDOM_WORD_6));
         repository.save(new Word(RANDOM_WORD_7));

--- a/src/test/java/nl/hu/cisq1/lingo/words/presentation/WordControllerIntegrationTest.java
+++ b/src/test/java/nl/hu/cisq1/lingo/words/presentation/WordControllerIntegrationTest.java
@@ -81,6 +81,7 @@ class WordControllerIntegrationTest {
     @BeforeEach
     void loadTestData() {
         // Load test fixtures into test database before each test case
+        repository.deleteAll();
         repository.save(new Word(RANDOM_WORD_5));
         repository.save(new Word(RANDOM_WORD_6));
         repository.save(new Word(RANDOM_WORD_7));


### PR DESCRIPTION
This fixes non-isolated test runs in case the test database supplied is not empty.

Fixes #50 